### PR TITLE
New supports for `@( …C#… )` statement code in XML attributes

### DIFF
--- a/Core.Tests/Parser/AttributeNameTestFixture.cs
+++ b/Core.Tests/Parser/AttributeNameTestFixture.cs
@@ -87,7 +87,10 @@ namespace MonoDevelop.Xml.Tests.Parser
 
 		static void AssertAttributeName (string doc, string? name)
 		{
-			TestXmlParser.Parse (doc, p => p.AssertNodeIs<XAttribute> ().AssertName (name));
+			TestXmlParser.Parse (doc, p => {
+				p.AssertNodeIf<XAttributeValue> ((p, _) => p.AssertNodeIf<XAttribute>((p, node) => node.AssertName(name), 1));
+				p.AssertNodeIf<XAttribute> ((_, node) => node.AssertName (name));
+			});
 		}
 
 		static void NotAttribute (string doc)

--- a/Core.Tests/Parser/AttributeNameUnderCursorTests.cs
+++ b/Core.Tests/Parser/AttributeNameUnderCursorTests.cs
@@ -35,8 +35,8 @@ namespace MonoDevelop.Xml.Tests.Parser
 		public void AssertAttributeName (string doc, string name)
 		{
 			TestXmlParser.Parse (doc, p => {
-				p.AssertNodeIs<XAttribute>();
-				p.AssertNodeName (name);
+				p.AssertNodeIf<XAttributeValue> ((p, _) => p.AssertNodeIf<XAttribute> ((p, n) => n.AssertName (name), 1));
+				p.AssertNodeIf<XAttribute>((p, _) => p.AssertNodeName(name));
 			});
 		}
 	}

--- a/Core.Tests/Parser/CSharpStatementTestFixture.cs
+++ b/Core.Tests/Parser/CSharpStatementTestFixture.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using MonoDevelop.Xml.Analysis;
+using MonoDevelop.Xml.Dom;
+using MonoDevelop.Xml.Parser;
+using NUnit.Framework;
+
+namespace MonoDevelop.Xml.Tests.Parser
+{
+	[TestFixture]
+	public class CSharpStatementTestFixture
+	{
+		[Test]
+		public void XmlAttributeValueState ()
+		{
+			AssertInsideAttributeValue ("<xml-element attribute=\"@$");
+		}
+
+		[Test]
+		public void EmptyCSharpStatement ()
+		{
+			var parser = new XmlTreeParser (new XmlRootState ());
+			var result = parser.Parse ("<set-variable value=\"@($)",
+				() => {
+					parser.AssertStateIs<XmlCSharpStatementState> ();
+				});
+
+			parser.AssertDiagnostics (
+				(XmlCoreDiagnostics.EmptyCSharpStatementValue, 21, 2),
+				(XmlCoreDiagnostics.IncompleteAttributeEof, 24, 0),
+				(XmlCoreDiagnostics.IncompleteTagEof, 24, 0)
+			);
+		}
+
+		[Test]
+		public void IncompleteCSharpStatement_Eof ()
+		{
+			var parser = new XmlTreeParser (new XmlRootState ());
+			var result = parser.Parse ("<set-variable value=\"@($",
+				() => {
+					parser.AssertStateIs<XmlCSharpStatementState> ();
+				});
+
+			parser.AssertDiagnostics (
+				(XmlCoreDiagnostics.IncompleteCSharpStatementEof, 21, 2),
+				(XmlCoreDiagnostics.EmptyCSharpStatementValue, 21, 2),
+				(XmlCoreDiagnostics.IncompleteAttributeEof, 23, 0),
+				(XmlCoreDiagnostics.IncompleteTagEof, 23, 0)
+			);
+		}
+
+		[TestCase("<set-variable value=\"@( \"hello, world!\"$ )\" />", " \"hello, world!\" ")] // "hello, world"
+		[TestCase("<set-variable value=\"@( (string)\"hello\"$ )\" />", " (string)\"hello\" ")] // (string)"hello"
+		[TestCase("<set-variable value=\"@( (string)\"(\"$ )\" />", " (string)\"(\" ")] // (string)"("
+		[TestCase("<set-variable value=\"@( (string)\")\"$ )\" />", " (string)\")\" ")] // (string)")"
+		[TestCase("<set-variable value=\"@( \"\\\"\"$ )\" />", " \"\\\"\" ")] // "\""
+		public void CSharpStatement (string xml, string expected)
+		{
+			var parser = new XmlTreeParser (new XmlRootState ());
+			var result = parser.Parse (xml,
+				() => {
+					parser.AssertStateIs<XmlCSharpStatementState> ();
+				});
+
+			var document = result.doc;
+			var root = document.RootElement;
+			var attribute = root!.Attributes.Single (att => att.Name == "value");
+
+			Assert.NotNull(attribute);
+			Assert.NotNull (attribute.Value);
+
+			Assert.True(XAttributeValue.IsCSharpStatement(attribute.Value));
+			Assert.AreEqual (expected, attribute.Value.As<XCSharpStatement> ().RawText ?? "");
+		}
+
+		public void AssertInsideAttributeValue (string doc)
+		{
+			TestXmlParser.Parse (doc, p => p.AssertStateIs<XmlAttributeValueState> ());
+		}
+	}
+}

--- a/Core.Tests/Parser/TestXmlParser.cs
+++ b/Core.Tests/Parser/TestXmlParser.cs
@@ -194,6 +194,13 @@ namespace MonoDevelop.Xml.Tests.Parser
 		public static T AssertNodeIs<T> (this XmlParser parser, int down = 0) where T : class
 			=> parser.AssertPeek(down).AssertCast<T> ();
 
+		public static void AssertNodeIf<T>(this XmlParser parser, Action<XmlParser, T> assert, int down = 0) where T : class
+		{
+			var node = parser.AssertPeek (down);
+			if (typeof (T).IsAssignableFrom (node.GetType ()))
+				assert (parser, (T)(object)node!);
+		}
+
 		public static void AssertNoDiagnostics (this (XDocument doc, IReadOnlyList<XmlDiagnostic>? diagnostics) parseResult, Func<XmlDiagnostic, bool>? filter = null) => AssertDiagnosticCount (parseResult.diagnostics, 0, filter);
 
 		public static void AssertDiagnosticCount (this (XDocument doc, IReadOnlyList<XmlDiagnostic>? diagnostics) parseResult, int count, Func<XmlDiagnostic, bool>? filter = null)
@@ -288,7 +295,7 @@ namespace MonoDevelop.Xml.Tests.Parser
 			foreach (XAttribute att in obj.Attributes) {
 				Assert.IsTrue (i < nameValuePairs.Length);
 				Assert.AreEqual (nameValuePairs[i], att.Name.FullName);
-				Assert.AreEqual (nameValuePairs[i + 1], att.Value);
+				Assert.AreEqual (nameValuePairs[i + 1], att.Value?.As<string> ());
 				i += 2;
 			}
 			Assert.AreEqual (nameValuePairs.Length, i);

--- a/Core/Analysis/XmlCoreDiagnostics.cs
+++ b/Core/Analysis/XmlCoreDiagnostics.cs
@@ -5,6 +5,20 @@ namespace MonoDevelop.Xml.Analysis
 {
 	class XmlCoreDiagnostics
 	{
+		public static XmlDiagnosticDescriptor EmptyCSharpStatementValue = new (
+			nameof (EmptyCSharpStatementValue),
+			"Empty C# statement",
+			"C# statement is invalid.",
+			XmlDiagnosticSeverity.Error
+		);
+
+		public static XmlDiagnosticDescriptor IncompleteCSharpStatementEof = new (
+			nameof (IncompleteCSharpStatementEof),
+			"Incomplete C# statement",
+			"C# statement is incomplete due to unexpected end of file.",
+			XmlDiagnosticSeverity.Error
+		);
+
 		public static XmlDiagnosticDescriptor IncompleteAttributeValue = new (
 			nameof (IncompleteAttributeValue),
 			"Incomplete attribute value",

--- a/Core/Completion/XmlElementPath.cs
+++ b/Core/Completion/XmlElementPath.cs
@@ -54,12 +54,15 @@ namespace MonoDevelop.Xml.Editor.Completion
 				if (el == null)
 					continue;
 				foreach (var att in el.Attributes) {
-					if (!string.IsNullOrEmpty (att.Value)) {
-						if (att.Name.HasPrefix) {
-							if (att.Name.Prefix == "xmlns" && att.Name.IsValid)
-								elementPath.Namespaces.AddPrefix (att.Value, att.Name.Name);
-						} else if (att.Name.Name == "xmlns") {
-							elementPath.Namespaces.AddPrefix (att.Value, "");
+					if (XAttributeValue.IsText(att.Value)) {
+						var value = att.Value!.As<string> ();
+						if (value != "") {
+							if (att.Name.HasPrefix) {
+								if (att.Name.Prefix == "xmlns" && att.Name.IsValid)
+									elementPath.Namespaces.AddPrefix (value, att.Name.Name);
+							} else if (att.Name.Name == "xmlns") {
+								elementPath.Namespaces.AddPrefix (value, "");
+							}
 						}
 					}
 				}
@@ -70,7 +73,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 			}
 			return elementPath;
 		}
-		
+
 		/// <summary>
 		/// Gets the elements specifying the path.
 		/// </summary>
@@ -80,7 +83,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 				return elements;
 			}
 		}
-		
+
 		/// <summary>
 		/// Compacts the path so it only contains the elements that are from 
 		/// the namespace of the last element in the path. 
@@ -88,22 +91,22 @@ namespace MonoDevelop.Xml.Editor.Completion
 		/// <remarks>This method is used when we need to know the path for a
 		/// particular namespace and do not care about the complete path.
 		/// </remarks>
-		public void Compact()
+		public void Compact ()
 		{
 			if (elements.Count > 0) {
 				QualifiedName lastName = Elements[Elements.Count - 1];
-				int index = FindNonMatchingParentElement(lastName.Namespace);
+				int index = FindNonMatchingParentElement (lastName.Namespace);
 				if (index != -1) {
-					RemoveParentElements(index);
+					RemoveParentElements (index);
 				}
 			}
 		}
-		
+
 		/// <summary>
 		/// An xml element path is considered to be equal if 
 		/// each path item has the same name and namespace.
 		/// </summary>
-		public override bool Equals(object? obj)
+		public override bool Equals (object? obj)
 		{
 			if (this == obj) {
 				return true;
@@ -114,15 +117,15 @@ namespace MonoDevelop.Xml.Editor.Completion
 			}
 
 			if (elements.Count == other.elements.Count) {
-				
+
 				for (int i = 0; i < elements.Count; ++i) {
-					if (!elements[i].Equals(other.elements[i])) {
+					if (!elements[i].Equals (other.elements[i])) {
 						return false;
 					}
 				}
 				return true;
 			}
-			
+
 			return false;
 		}
 
@@ -131,7 +134,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 		/// <summary>
 		/// Removes elements up to and including the specified index.
 		/// </summary>
-		void RemoveParentElements(int index)
+		void RemoveParentElements (int index)
 		{
 			while (index >= 0) {
 				--index;
@@ -139,15 +142,15 @@ namespace MonoDevelop.Xml.Editor.Completion
 					elements.RemoveAt (0);
 			}
 		}
-		
+
 		/// <summary>
 		/// Finds the first parent that does belong in the specified
 		/// namespace.
 		/// </summary>
-		int FindNonMatchingParentElement(string namespaceUri)
+		int FindNonMatchingParentElement (string namespaceUri)
 		{
 			int index = -1;
-			
+
 			if (elements.Count > 1) {
 				// Start the check from the the last but one item.
 				for (int i = elements.Count - 2; i >= 0; --i) {

--- a/Core/Dom/XAttribute.cs
+++ b/Core/Dom/XAttribute.cs
@@ -31,7 +31,7 @@ namespace MonoDevelop.Xml.Dom
 	public class XAttribute : XObject, INamedXObject
 	{
 
-		public XAttribute (int startOffset, XName name, string value) : base (startOffset)
+		public XAttribute (int startOffset, XName name, XAttributeValue value) : base (startOffset)
 		{
 			Name = name;
 			Value = value;
@@ -45,7 +45,7 @@ namespace MonoDevelop.Xml.Dom
 
 		public bool IsNamed => Name.IsValid;
 
-		public string? Value { get; set; }
+		public XAttributeValue? Value { get; set; }
 
 		public XAttribute? NextSibling { get; internal protected set; }
 

--- a/Core/Dom/XAttributeCollection.cs
+++ b/Core/Dom/XAttributeCollection.cs
@@ -93,7 +93,7 @@ namespace MonoDevelop.Xml.Dom
 			return null;
 		}
 
-		public string? GetValue (XName name, bool ignoreCase) => Get (name, ignoreCase)?.Value;
+		public XAttributeValue? GetValue (XName name, bool ignoreCase) => Get (name, ignoreCase)?.Value;
 
 		public void AddAttribute (XAttribute newChild)
 		{

--- a/Core/Dom/XAttributeValue.cs
+++ b/Core/Dom/XAttributeValue.cs
@@ -28,10 +28,6 @@ using System;
 
 namespace MonoDevelop.Xml.Dom
 {
-	public class XCSharpStatement
-	{
-	}
-
 	public class XAttributeValue : XNode
 	{
 		XCSharpStatement? statement_;
@@ -47,7 +43,13 @@ namespace MonoDevelop.Xml.Dom
 		public void End (string text)
 		{
 			text_ = text;
-			Span = new TextSpan(Span.Start, text_.Length);
+			Span = new TextSpan (Span.Start, text_.Length);
+		}
+
+		public void End (XCSharpStatement statement)
+		{
+			statement_ = statement;
+			Span = new TextSpan (Span.Start, statement_.Length + 2);
 		}
 
 		protected XAttributeValue () { }

--- a/Core/Dom/XAttributeValue.cs
+++ b/Core/Dom/XAttributeValue.cs
@@ -1,0 +1,91 @@
+//
+// XAttributeValue.cs
+//
+// Author:
+//   springcomp <springcomp@users.noreply.github.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#nullable enable
+
+using System;
+
+namespace MonoDevelop.Xml.Dom
+{
+	public class XCSharpStatement
+	{
+	}
+
+	public class XAttributeValue : XNode
+	{
+		XCSharpStatement? statement_;
+		string? text_;
+
+		public XAttributeValue (int startOffset) : base(startOffset) { }
+
+		public XAttributeValue (string text)
+		{
+			text_ = text;
+		}
+
+		public void End (string text)
+		{
+			text_ = text;
+			Span = new TextSpan(Span.Start, text_.Length);
+		}
+
+		protected XAttributeValue () { }
+		protected override XObject NewInstance () => new XAttributeValue ();
+
+		public int Length => text_!.Length;
+
+		internal bool IsNull => text_ == null && statement_ == null;
+
+		public static bool IsText (XAttributeValue? value) => value?.text_ != null;
+		public static bool IsCSharpStatement(XAttributeValue? value) => value?.statement_ != null;
+
+		public T As<T> ()
+		{
+			var typeName = typeof (T).FullName;
+			if (typeName == "System.String") {
+				if (text_ == null) throw new InvalidCastException (typeName);
+				return (T)(object)text_!;
+			}
+			if (typeName == "MonoDevelop.Xml.Dom.XCSharpStatement") {
+				if (statement_ == null) throw new InvalidCastException (typeName);
+				return (T)(object)statement_!;
+			} else
+				throw new InvalidCastException (typeName);
+		}
+
+		public override string ToString () => $"[XAttributeValue Location='{Span}' Value='{GetValueRepresentation()}']";
+
+		public override string FriendlyPathRepresentation => GetValueRepresentation();
+
+		private string GetValueRepresentation ()
+		{
+			if (text_ != null)
+				return text_!;
+			else if (statement_ != null)
+				return statement_!.ToString () ?? "";
+			else
+				return "null";
+		}
+	}
+}

--- a/Core/Dom/XCSharpStatement.cs
+++ b/Core/Dom/XCSharpStatement.cs
@@ -1,0 +1,49 @@
+//
+// XAttributeValue.cs
+//
+// Author:
+//   springcomp <springcomp@users.noreply.github.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#nullable enable
+
+using System;
+
+namespace MonoDevelop.Xml.Dom
+{
+	public class XCSharpStatement : XNode
+	{
+		private string? text_;
+		public XCSharpStatement (int startOffset) : base (startOffset) { }
+		protected XCSharpStatement () { }
+		protected override XObject NewInstance () => new XCSharpStatement ();
+
+		public string? RawText {
+			get => text_;
+			internal set => text_ = value;
+		}
+
+		public int Length => text_ != null ? text_.Length : 0;
+
+		public override string ToString () => $"[XCSharpStatement Location='{Span}' Value='{GetValueRepresentation ()}']";
+
+		private string GetValueRepresentation () => text_! ?? "";
+	}
+}

--- a/Core/Dom/XmlDomExtensions.cs
+++ b/Core/Dom/XmlDomExtensions.cs
@@ -22,11 +22,11 @@ namespace MonoDevelop.Xml.Dom
 			return !obj.Name.HasPrefix && string.Equals (obj.Name.Name, name, comparison);
 		}
 
-		public static bool IsTrue (this XAttributeCollection attributes, string name)
-		{
-			var att = attributes.Get (name, true);
-			return att != null && string.Equals (att.Value, "true", StringComparison.OrdinalIgnoreCase);
-		}
+		//public static bool IsTrue (this XAttributeCollection attributes, string name)
+		//{
+		//	var att = attributes.Get (name, true);
+		//	return att != null && string.Equals (att.Value, "true", StringComparison.OrdinalIgnoreCase);
+		//}
 
 		static XAttribute? FindAttribute (this IAttributedXObject attContainer, int offset)
 		{
@@ -114,16 +114,16 @@ namespace MonoDevelop.Xml.Dom
 			? null
 			: TextSpan.FromBounds (obj.Attributes.First.Span.Start, obj.Attributes.Last.Span.End);
 
-		public static Dictionary<string, string> ToDictionary (this XAttributeCollection attributes, StringComparer comparer)
-		{
-			var dict = new Dictionary<string, string> (comparer);
-			foreach (XAttribute a in attributes) {
-				if (a.Name.IsValid) {
-					dict[a.Name.FullName] = a.Value ?? string.Empty;
-				}
-			}
-			return dict;
-		}
+		//public static Dictionary<string, string> ToDictionary (this XAttributeCollection attributes, StringComparer comparer)
+		//{
+		//	var dict = new Dictionary<string, string> (comparer);
+		//	foreach (XAttribute a in attributes) {
+		//		if (a.Name.IsValid) {
+		//			dict[a.Name.FullName] = a.Value ?? string.Empty;
+		//		}
+		//	}
+		//	return dict;
+		//}
 
 		public static XNode? FindPreviousNode (this XNode node) => node.FindPreviousSibling () ?? node.Parent as XNode;
 

--- a/Core/Parser/XmlAttributeState.cs
+++ b/Core/Parser/XmlAttributeState.cs
@@ -72,8 +72,7 @@ namespace MonoDevelop.Xml.Parser
 						return Parent;
 					}
 					context.StateTag = GETTINGEQ;
-				}
-				else if (context.PreviousState is XmlAttributeValueState) {
+				} else if (context.PreviousState is XmlAttributeValueState) {
 					if (att is null) {
 						InvalidParserStateException.ThrowExpected<XAttribute> (context);
 					}

--- a/Core/Parser/XmlCSharpStatementState.cs
+++ b/Core/Parser/XmlCSharpStatementState.cs
@@ -1,0 +1,135 @@
+//
+// XmlCSharpStatementState.cs
+//
+// Author:
+//   springcomp <springcomp@users.noreply.github.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Mime;
+using MonoDevelop.Xml.Analysis;
+using MonoDevelop.Xml.Dom;
+
+namespace MonoDevelop.Xml.Parser
+{
+	public class XmlCSharpStatementState : XmlParserState
+	{
+		const int START_OFFSET = 2; // "@("
+
+		const int FREE = 0;
+		const int MATCH_QUOTE = 1;
+		const int MATCH_PARENS = 2;
+
+		const int ESCAPE = 3;
+
+		const string ESCAPED_CHARS = "\\\"\t\r\n";
+
+		private Stack<int> unmatchedQuotes_ = new ();
+		private Stack<int> unmatchedParens_ = new ();
+
+		private Stack<int> states_ = new ();
+
+		public override XmlParserState? PushChar (char c, XmlParserContext context, ref bool replayCharacter, bool isEndOfFile)
+		{
+			var statement = context.Nodes.Peek () as XCSharpStatement;
+
+			//state has just been entered
+			if (context.CurrentStateLength == 0 || statement is null) {
+				statement = new XCSharpStatement (context.PositionBeforeCurrentChar - START_OFFSET);
+				context.Nodes.Push (statement);
+				context.StateTag = FREE;
+			}
+
+			if (isEndOfFile) {
+				//the parent state should report the error
+				return End (isEndOfFile);
+			}
+
+			switch (context.StateTag) {
+			case FREE:
+				if (c == '"') {
+					unmatchedQuotes_.Push (context.Position);
+					context.StateTag = MATCH_QUOTE;
+				}
+				if (c == '(') {
+					unmatchedParens_.Push (context.Position);
+					context.StateTag = MATCH_PARENS;
+				}
+				if (c == ')') {
+					// ending the C# statement
+					return End ();
+				}
+				break;
+
+			case MATCH_QUOTE:
+				if (c == '\\') {
+					states_.Push (context.StateTag);
+					context.StateTag = ESCAPE;
+				}
+				if (c == '"') {
+					Debug.Assert (unmatchedQuotes_.Count > 0);
+					unmatchedQuotes_.Pop ();
+					context.StateTag = FREE;
+				}
+				break;
+			case MATCH_PARENS:
+				if (c == ')') {
+					Debug.Assert (unmatchedParens_.Count > 0);
+					unmatchedParens_.Pop ();
+					context.StateTag = FREE;
+				}
+				break;
+			case ESCAPE:
+				if (ESCAPED_CHARS.Contains (new string (c, 1))) {
+					Debug.Assert (states_.Count > 0);
+					context.StateTag = states_.Pop ();
+					// TODO: \uXXXX Unicode
+					// TODO: \xXXXX
+				}
+				break;
+			}
+
+			context.KeywordBuilder.Append (c);
+			return null;
+
+			XmlParserState? End (bool? isEndOfFile = false)
+			{
+				var statement = (XCSharpStatement)context.Nodes.Peek ();
+				statement.RawText = context.KeywordBuilder.ToString ();
+				statement.End (context.PositionBeforeCurrentChar);
+				if (isEndOfFile == true) {
+					context.Diagnostics?.Add (XmlCoreDiagnostics.IncompleteCSharpStatementEof, statement.Span);
+				}
+				if (statement.RawText?.Length == 0) {
+					context.Diagnostics?.Add (XmlCoreDiagnostics.EmptyCSharpStatementValue, statement.Span);
+				}
+
+				return Parent;
+			}
+		}
+
+		public override XmlParserContext? TryRecreateState (ref XObject xobject, int position)
+			=> throw new InvalidOperationException ("State has no corresponding XObject");
+	}
+}


### PR DESCRIPTION
This PR introduces support for C# code statement in XML attributes.

Example:

```xml
<policies>
  <inbound>
    <set-variable name="my" value="@( (string)"hello, world" )" />
    <base />
  </inbound>
</policies>
```